### PR TITLE
Add PSVR2-compatible left/right controller detection

### DIFF
--- a/Scripts/PortablePanel.cs
+++ b/Scripts/PortablePanel.cs
@@ -570,6 +570,8 @@ namespace myro
 			{
 				if (input.ToLower().Contains("left"))
 					return true;
+				if (input.ToLower().Contains("(l)")) // PSVR2 and some niche controllers use this naming scheme
+					return true;
 			}
 			return false;
 		}
@@ -580,6 +582,8 @@ namespace myro
 			foreach (string input in inputs)
 			{
 				if (input.ToLower().Contains("right"))
+					return true;
+				if (input.ToLower().Contains("(r)")) // PSVR2 and some niche controllers use this naming scheme
 					return true;
 			}
 			return false;


### PR DESCRIPTION
Fixes #9 

PSVR2 is the most (in)famous example that doesn't name it's controllers Left/Right, but shoehorns it in with (L) and (R) instead.

This tiny patch adds a second set of checks for this alternative left/right naming scheme.

It does not attempt to "optimize" things by caching the toLower call into a variable, as compilers for over 20 years have done common subexpression elimination so simple readable code w/ contextual comments for the new lines seemed preferable for this patch.